### PR TITLE
Create issue

### DIFF
--- a/tests/snapshots/integration_test__connect.snap
+++ b/tests/snapshots/integration_test__connect.snap
@@ -8,7 +8,7 @@ expression: messages
     id: "[uuid]",
     title: "coronvorus bad??",
     description: "yes or yes",
-    state: inprogress,
+    state: Some(inprogress),
     alternatives: [
       Alternative(
         id: "[uuid]",
@@ -23,8 +23,8 @@ expression: messages
         title: "my name is trump i have control",
       ),
     ],
-    votes: [],
-    max_voters: 10,
+    votes: Some([]),
+    max_voters: Some(10),
     show_distribution: true,
   ),
 ]


### PR DESCRIPTION
* Handles CreateIssue event coming from frontend. Well. Not really. It debug prints a message.
* Sets some Issue fields to Option<> since they should not be set in frontend. Examples: Id, issue state, votes, max_voters. These should either be set by the back end upon some event (id: creation in DB, issue state should always be NOT_STARTED (?), votes are obviously empty by default, and the front end should not be able to send in a list of votes (empty or not), max_voters is probably defined upon state change into IN_PROGRESS).
* (Maybe defines the way of how events should be named, the "type" of this event is `issue_create`. Since we haven't discussed the naming scheme for these events I just ran with this for now.)

Connected to https://github.com/vaas-org/vaas-front/pull/8